### PR TITLE
Add event selection to post creation and edit forms

### DIFF
--- a/src/routes/new-post/+page.svelte
+++ b/src/routes/new-post/+page.svelte
@@ -15,10 +15,8 @@
             await fetchEvents();
         }
         
-        // Use the first available event if there's at least one
-        if ($events.length > 0) {
-            eventId = $events[0].id;
-        }
+        // Don't automatically select an event, let the user choose
+        eventId = "";
     });
     const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB in bytes
 
@@ -55,16 +53,7 @@
             }
             
             if (!eventId) {
-                // If we don't have an event ID yet, try to get one
-                if ($events.length === 0) {
-                    await fetchEvents();
-                }
-                
-                if ($events.length > 0) {
-                    eventId = $events[0].id;
-                } else {
-                    throw new Error('No events available. Please try again later.');
-                }
+                throw new Error('Please select an event for your post.');
             }
 
             const formData = new FormData();
@@ -149,6 +138,19 @@
                     bind:value={description}
                     required
                 ></textarea>
+            </label>
+            <label class="label">
+                <span>Event</span>
+                <select 
+                    class="select px-4 py-2"
+                    bind:value={eventId}
+                    required
+                >
+                    <option value="">Select an event</option>
+                    {#each $events as event}
+                        <option value={event.id}>{event.displayName}</option>
+                    {/each}
+                </select>
             </label>
             <label class="label">
                 <span>Upload Images (Max 10MB per image)</span>


### PR DESCRIPTION
## Summary
- Added dropdown menu for event selection in the post creation form
- Made event selection mandatory with validation
- Added the same event selection functionality to post edit form
- Default to empty selection rather than auto-selecting first event

## Test plan
- Create a new post and verify that the event dropdown shows all events correctly
- Try to submit a post without selecting an event and confirm validation works
- Edit an existing post and verify that the current event is pre-selected
- Change the event for an existing post and confirm the change is saved correctly

Closes #2