### PR TITLE
Enhance landing page with event links and top posts

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -119,10 +119,19 @@
     <svelte:fragment slot="header">
         <AppBar>
             <svelte:fragment slot="lead">
-                <Shell class="mr-2" />
-                <strong class="text-xl uppercase"
-                    ><span class="gradient-heading">Vibe Chuck</span></strong
+                <div 
+                    class="flex items-center cursor-pointer" 
+                    on:click={() => goto('/')}
+                    on:keydown={(e) => e.key === 'Enter' && goto('/')}
+                    tabindex="0"
+                    role="link"
+                    aria-label="Go to home page"
                 >
+                    <Shell class="mr-2" />
+                    <strong class="text-xl uppercase"
+                        ><span class="gradient-heading">Vibe Chuck</span></strong
+                    >
+                </div>
                 <button
                     type="button"
                     class="btn-icon btn-icon-sm bg-gradient-to-br variant-gradient-tertiary-primary ml-6"

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,0 +1,63 @@
+import { pbStore } from '$lib/pocketbase';
+
+export const load = async () => {
+  try {
+    const pb = await pbStore.init(); // Ensure the client is initialized
+    
+    // Fetch all events
+    const events = await pb.collection('events').getFullList({
+      sort: '-start',
+    });
+    
+    // Only get posts from events that have already started
+    const currentDate = new Date();
+    const activeEvents = events.filter(event => new Date(event.start) <= currentDate);
+    
+    // Prepare posts data structure
+    let topPosts = [];
+    
+    // Fetch top 2 posts for each active event
+    for (const event of activeEvents) {
+      const { items } = await pb.collection('posts').getList(1, 2, {
+        filter: `event = "${event.id}" && rank > 0`,
+        sort: 'rank',
+        expand: 'op',
+      });
+      
+      if (items.length > 0) {
+        // Map over records to construct image URLs and include user information
+        const posts = items.map((record) => {
+          const imgs = record.imgs?.map(img => pb.getFileUrl(record, img)) || [];
+          return {
+            id: record.id,
+            title: record.title,
+            imgs,
+            rank: record.rank,
+            event: record.event,
+            description: record.description,
+            op: record.expand?.op?.username || record.op,
+            votes: record.votes,
+            eventDisplayName: event.displayName
+          };
+        });
+        
+        topPosts = [...topPosts, ...posts];
+      }
+    }
+    
+    // Sort by rank and limit to top 6 posts
+    topPosts.sort((a, b) => a.rank - b.rank);
+    topPosts = topPosts.slice(0, 6);
+    
+    return {
+      topPosts
+    };
+  } catch (err) {
+    console.error('Error fetching data for landing page:', err);
+    return {
+      topPosts: []
+    };
+  }
+};
+
+export const ssr = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,13 +1,19 @@
 <script>
     import { onMount } from 'svelte';
-    import { fly } from 'svelte/transition';
+    import { fly, fade } from 'svelte/transition';
     import { elasticOut } from 'svelte/easing';
     import { Shell } from 'lucide-svelte';
     import { events, fetchEvents } from '$lib/stores/events';
     import { goto } from '$app/navigation';
     import { getToastStore } from '@skeletonlabs/skeleton';
+    import Post from '$lib/Post.svelte';
+    import FullScreenPost from '$lib/FullScreenPost.svelte';
+    
+    export let data;
+    const { topPosts } = data;
     
     let animatingEvents = [];
+    let showPosts = false;
     const toastStore = getToastStore();
     
     function formatDate(date) {
@@ -35,6 +41,16 @@
         }
     }
     
+    let fullScreenPost = null;
+    
+    function openFullScreen(event) {
+        fullScreenPost = event.detail.post;
+    }
+    
+    function closeFullScreen() {
+        fullScreenPost = null;
+    }
+    
     onMount(async () => {
         // Fetch events if needed
         if ($events.length === 0) {
@@ -47,18 +63,31 @@
                 animatingEvents = [...animatingEvents, event];
             }, index * 300); // Stagger the animations
         });
+        
+        // Show posts after events have appeared
+        setTimeout(() => {
+            showPosts = true;
+        }, $events.length * 300 + 500);
     });
 </script>
 
 <div class="flex flex-col items-center justify-center min-h-screen py-16 space-y-10">
-    <h2 class="flex items-center space-x-4 text-8xl uppercase mb-8">
+    <h2 
+        class="flex items-center space-x-4 text-8xl uppercase mb-8 cursor-pointer"
+        on:click={() => goto('/')}
+        on:keydown={(e) => e.key === 'Enter' && goto('/')}
+        tabindex="0"
+        role="link"
+        aria-label="Go to home page"
+    >
         <Shell class="w-16 h-16" />
         <span class="bg-clip-text text-transparent bg-gradient-to-br variant-gradient-tertiary-primary">
             VIBE CHUCK
         </span>
     </h2>
     
-    <div class="flex flex-col items-center mt-4 space-y-3">
+    <div class="flex flex-col items-center mt-4 space-y-10 w-full">
+        <!-- Event cards -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-w-4xl">
             {#each animatingEvents as event, i (event.id)}
                 <button 
@@ -86,5 +115,34 @@
                 </button>
             {/each}
         </div>
+        
+        <!-- Top posts section -->
+        {#if showPosts && topPosts.length > 0}
+            <div in:fade={{ duration: 800 }} class="mt-12 w-full max-w-5xl">
+                <h3 class="text-2xl font-bold text-center mb-6">Top Posts</h3>
+                
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {#each topPosts as post, i}
+                        <div in:fly={{ 
+                            y: 50, 
+                            delay: i * 150, 
+                            duration: 600, 
+                            easing: elasticOut 
+                        }}>
+                            <div class="relative">
+                                <Post {post} on:openFullScreen={openFullScreen} />
+                                <div class="absolute top-3 right-3 z-20">
+                                    <span class="badge variant-filled-secondary">{post.eventDisplayName}</span>
+                                </div>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        {/if}
     </div>
 </div>
+
+{#if fullScreenPost}
+    <FullScreenPost post={fullScreenPost} on:close={closeFullScreen} />
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,14 +72,7 @@
 </script>
 
 <div class="flex flex-col items-center justify-center min-h-screen py-16 space-y-10">
-    <h2 
-        class="flex items-center space-x-4 text-8xl uppercase mb-8 cursor-pointer"
-        on:click={() => goto('/')}
-        on:keydown={(e) => e.key === 'Enter' && goto('/')}
-        tabindex="0"
-        role="link"
-        aria-label="Go to home page"
-    >
+    <h2 class="flex items-center space-x-4 text-8xl uppercase mb-8">
         <Shell class="w-16 h-16" />
         <span class="bg-clip-text text-transparent bg-gradient-to-br variant-gradient-tertiary-primary">
             VIBE CHUCK

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,29 +1,90 @@
 <script>
     import { onMount } from 'svelte';
-    import { fade } from 'svelte/transition';
+    import { fly } from 'svelte/transition';
+    import { elasticOut } from 'svelte/easing';
     import { Shell } from 'lucide-svelte';
-    let showFirst = false;
-    let showSecond = false;
-    onMount(() => {
-        // fade in the first line immediately
-        showFirst = true;
-        // fade in the second line after a brief delay
-        setTimeout(() => showSecond = true, 1000);
+    import { events, fetchEvents } from '$lib/stores/events';
+    import { goto } from '$app/navigation';
+    import { getToastStore } from '@skeletonlabs/skeleton';
+    
+    let animatingEvents = [];
+    const toastStore = getToastStore();
+    
+    function formatDate(date) {
+        return new Date(date).toLocaleString(undefined, {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        });
+    }
+    
+    function isEventInFuture(eventStartDate) {
+        const currentDate = new Date();
+        const startDate = new Date(eventStartDate);
+        return startDate > currentDate;
+    }
+    
+    function handleEventClick(event) {
+        if (isEventInFuture(event.start)) {
+            toastStore.trigger({
+                message: `Event "${event.displayName}" starts on ${formatDate(event.start)}`,
+                background: "variant-filled-primary",
+            });
+        } else {
+            goto(`/events/${event.id}`);
+        }
+    }
+    
+    onMount(async () => {
+        // Fetch events if needed
+        if ($events.length === 0) {
+            await fetchEvents();
+        }
+        
+        // Animate events appearing one by one
+        $events.forEach((event, index) => {
+            setTimeout(() => {
+                animatingEvents = [...animatingEvents, event];
+            }, index * 300); // Stagger the animations
+        });
     });
 </script>
 
-<div class="flex flex-col items-center justify-center h-screen space-y-6">
-    {#if showFirst}
-        <h1 in:fade={{ duration: 800 }} class="text-6xl font-extrabold">
-            Will you pass...
-        </h1>
-    {/if}
-    {#if showSecond}
-        <h2 in:fade={{ duration: 800 }} class="flex items-center space-x-4 text-8xl uppercase">
-            <Shell class="w-16 h-16" />
-            <span class="bg-clip-text text-transparent bg-gradient-to-br variant-gradient-tertiary-primary">
-                the VIBE CHUCK?
-            </span>
-        </h2>
-    {/if}
+<div class="flex flex-col items-center justify-center min-h-screen py-16 space-y-10">
+    <h2 class="flex items-center space-x-4 text-8xl uppercase mb-8">
+        <Shell class="w-16 h-16" />
+        <span class="bg-clip-text text-transparent bg-gradient-to-br variant-gradient-tertiary-primary">
+            VIBE CHUCK
+        </span>
+    </h2>
+    
+    <div class="flex flex-col items-center mt-4 space-y-3">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 max-w-4xl">
+            {#each animatingEvents as event, i (event.id)}
+                <button 
+                    class="card p-4 bg-gradient-to-br variant-gradient-secondary-primary text-white text-xl font-semibold
+                           transition-transform hover:scale-105 hover:shadow-lg hover:z-10 {isEventInFuture(event.start) ? 'opacity-75' : ''}"
+                    in:fly={{ 
+                        y: 50, 
+                        x: Math.sin(i) * 20, 
+                        duration: 600,
+                        delay: i * 100,
+                        easing: elasticOut
+                    }}
+                    on:click={() => handleEventClick(event)}
+                >
+                    <div class="flex items-center justify-between">
+                        <span>{event.displayName}</span>
+                        {#if isEventInFuture(event.start)}
+                            <span class="badge variant-filled-warning text-xs">Upcoming</span>
+                        {/if}
+                    </div>
+                    <div class="text-sm mt-2 opacity-90 flex items-center">
+                        <span class="badge variant-soft-primary text-xs mr-2">Starts</span>
+                        {formatDate(event.start)}
+                    </div>
+                </button>
+            {/each}
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- Add animated event card links on the landing page
- Display top posts from active events in a grid layout
- Enable fullscreen view for posts when clicked
- Add home page navigation through logo
- Show event badges on posts for context

## Test plan
- Visit the landing page and verify event cards appear with animations
- Check that event cards link to their respective event pages
- Verify top posts appear and display content correctly
- Test fullscreen view by clicking on posts
- Confirm clicking the logo navigates back to home page

closes #5